### PR TITLE
Pin compiler version to nightly 2024-03-09 for experimental API

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-03-09"


### PR DESCRIPTION
Hey,

I noticed this project seems to depend on an experimental API (`.extract_if()`) that no longer works on a recent nightly compiler the way that this project expects it to. It might be useful to pin the required version of the compiler to the project.

**Broken in:**

```console
$ rustup run nightly-2025-04-24 cargo run --features=syscalls --example strace
```

Snippets from the erroneus output:

```
error[E0282]: type annotations needed
...
     |
3220 |             .extract_if(|x| !x.name.subname.is_empty())
     |                          ^   - type must be known at this point
...
error[E0061]: this method takes 2 arguments but 1 argument was supplied
...
     |
3220 |             .extract_if(|x| !x.name.subname.is_empty())
     |              ^^^^^^^^^^-------------------------------- argument #2 is missing
...
error: could not compile `syzlang-parser` (lib) due to 13 previous errors
```

**Works in:**

```console
$ rustup run nightly-2024-03-09 cargo run --features=syscalls --example strace
```

2024-03-09 being the date of your last commit.